### PR TITLE
browse() returns an error when not interactive

### DIFF
--- a/R/browse.R
+++ b/R/browse.R
@@ -13,7 +13,7 @@
 #' @param ... Further args passed on to `utils::browseURL`
 #' (must be a named parameter)
 #' @return if in interactive mode, opens a URL in your default browser; 
-#' if not, then prints the URL in the console
+#' if not, then returns an error
 #' @author Ben Tupper \email{btupper@@bigelow.org}
 #' @examples \dontrun{
 #' if (interactive()) {

--- a/man/browse.Rd
+++ b/man/browse.Rd
@@ -19,7 +19,7 @@ more information}
 }
 \value{
 if in interactive mode, opens a URL in your default browser;
-if not, then prints the URL in the console
+if not, then returns an error
 }
 \description{
 Note that it is an error to call this when \code{base::interactive()}


### PR DESCRIPTION
<!-- Please use a feature branch (i.e., put your work in a new branch that has a name that reflects the feature you are working on; https://docs.gitlab.com/ee/workflow/workflow.html) -->

<!-- If authentication is involved: do not share your username/password, or api keys/tokens in this pull request - most likely the maintainer will have their own equivalent key -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->
# Update documentation of `rerddap::browse()`

## Description
The docs of `rerddap::browse()` indicate that, if `interactive() = FALSE`, then the function returns the URL of the dataset, but in fact it returns an error.  I just quickly updated the docs.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
Found out by running `rerddap` on jupyter notebooks, relates to https://github.com/jupyter/notebook/issues/5151
